### PR TITLE
Tag node pools

### DIFF
--- a/terraform/config/development.tfvars.json
+++ b/terraform/config/development.tfvars.json
@@ -9,6 +9,7 @@
   "node_pools": {
     "Find postgraduate teacher training": {
       "pool_name": "bat",
+      "product_name": "Find postgraduate teacher training",
       "node_count": 1,
       "vm_size": "Standard_D2_v2"
     }

--- a/terraform/config/development.tfvars.json
+++ b/terraform/config/development.tfvars.json
@@ -5,5 +5,12 @@
     "qa",
     "staging",
     "test"
-  ]
+  ],
+  "node_pools": {
+    "Find postgraduate teacher training": {
+      "pool_name": "bat",
+      "node_count": 1,
+      "vm_size": "Standard_D2_v2"
+    }
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,6 +30,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "app-node-pools" {
   node_count            = each.value.node_count
   vm_size               = each.value.vm_size
   tags = {
-    "Product" : each.key
+    "Product" : each.value.product_name
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,3 +21,17 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   lifecycle { ignore_changes = [tags] }
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "tra-node-pool" {
+  name                  = "tra"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
+  node_count            = 1
+  vm_size               = "Standard_D2_v2"
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "bat-node-pool" {
+  name                  = "bat"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
+  node_count            = 1
+  vm_size               = "Standard_D2_v2"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,22 +22,14 @@ resource "azurerm_kubernetes_cluster" "main" {
   lifecycle { ignore_changes = [tags] }
 }
 
-resource "azurerm_kubernetes_cluster_node_pool" "tra-node-pool" {
-  name                  = "tra"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
-  node_count            = 1
-  vm_size               = "Standard_D2_v2"
-  tags = {
-    "Product" : "Refer Serious Misconduct"
-  }
-}
+resource "azurerm_kubernetes_cluster_node_pool" "app-node-pools" {
+  for_each = var.node_pools
 
-resource "azurerm_kubernetes_cluster_node_pool" "bat-node-pool" {
-  name                  = "bat"
+  name                  = each.value.pool_name
   kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
-  node_count            = 1
-  vm_size               = "Standard_D2_v2"
+  node_count            = each.value.node_count
+  vm_size               = each.value.vm_size
   tags = {
-    "Product" : "Find postgraduate teacher training"
+    "Product" : each.key
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,6 +27,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "tra-node-pool" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
   node_count            = 1
   vm_size               = "Standard_D2_v2"
+  tags = {
+    "Product" : "Refer Serious Misconduct"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "bat-node-pool" {
@@ -34,4 +37,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "bat-node-pool" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
   node_count            = 1
   vm_size               = "Standard_D2_v2"
+  tags = {
+    "Product" : "Find postgraduate teacher training"
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,20 @@ variable "resource_group_name" {}
 # Set in config json file
 variable "cip_tenant" { type = bool }
 variable "namespaces" {}
+variable "node_pools" {
+    type = map(object({
+        pool_name = string
+        node_count = number
+        vm_size = string
+    }))
+
+    validation {
+        condition = alltrue([for p in var.node_pools : length(p.pool_name) < 13])
+        error_message = "The pool_name must be 12 characters or less."
+    }
+
+    //TO DO: establish naming convention for node pools
+}
 
 locals {
     cluster_name = (

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,6 +9,7 @@ variable "namespaces" {}
 variable "node_pools" {
     type = map(object({
         pool_name = string
+        product_name = string //this needs to be a separate property to prevent destruction when changing node_pool tags
         node_count = number
         vm_size = string
     }))


### PR DESCRIPTION
### Context

In order to report on costs we need to be able to tag Azure resources by Product

### Changes proposed in this PR

- Implements an approach to tag AKS Node Pools with a Product tag distinct from the cluster Product tag.  At present this depends on an exemption being applied to the `DfE-PaaS - Tagging` policy.  If the exemption is not applied the tags will be overwritten by the policy.
- This approach does *not* work for resources created via the Kubernetes terraform provider (eg Public IPs for ingress controllers)