### PR TITLE
Create dev cluster dns a record

### DIFF
--- a/terraform/config/development.tfvars.json
+++ b/terraform/config/development.tfvars.json
@@ -5,5 +5,7 @@
     "qa",
     "staging",
     "test"
-  ]
+  ],
+  "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
+  "cluster_dns_zone": "development.teacherservices.cloud"
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,21 @@
+data "kubernetes_service" "default" {
+  metadata {
+    name = "ingress-nginx-controller"
+  }
+
+  depends_on = [
+    helm_release.ingress-nginx
+    ]
+
+}
+
+resource "azurerm_dns_a_record" "cluster_a_record" {
+
+  count = var.cluster_dns_zone != null ? 1 : 0
+
+  name                = "*.${var.environment}"
+  zone_name           = var.cluster_dns_zone
+  resource_group_name = var.cluster_dns_resource_group_name
+  ttl                 = 300
+  records             = toset([data.kubernetes_service.default.status.0.load_balancer.0.ingress[0].ip])
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,8 @@
 variable "environment" {}
 variable "resource_prefix" {}
 variable "resource_group_name" {}
+variable "cluster_dns_resource_group_name" { default = null }
+variable "cluster_dns_zone" { default = null }
 
 # Set in config json file
 variable "cip_tenant" { type = bool }


### PR DESCRIPTION
**Context**

For development clusters, we want to automatically add a cluster DNS record in the DNS zone on build.
It will only create an A record if the variables are not null.
i.e. cluster_dns_zone & cluster_dns_resource_group_name

**Changes proposed in this pull request**

- Add dns.tf for DNS terraform resources
- Add new variables to tfvars and variables.tf

**Guidance to review**

make development terraform-plan ENVIRONMENT=cluster5


