### PR TITLE
Add development NS delegation record to prod DNS

### DIFF
--- a/custom_domains/infrastructure/main.tf
+++ b/custom_domains/infrastructure/main.tf
@@ -3,3 +3,13 @@ module "domains_infrastructure" {
   hosted_zone = var.hosted_zone
   tags        = var.tags
 }
+
+resource "azurerm_dns_ns_record" "dev_ns_record" {
+  count = var.delegation_name != null ? 1 : 0
+
+  name                = var.delegation_name
+  zone_name           = keys(var.hosted_zone)[0]
+  resource_group_name = var.hosted_zone[keys(var.hosted_zone)[0]].resource_group_name
+  records             = var.delegation_ns
+  ttl                 = 300
+}

--- a/custom_domains/infrastructure/variables.tf
+++ b/custom_domains/infrastructure/variables.tf
@@ -4,3 +4,11 @@ variable "hosted_zone" {
 
 variable "tags" {
 }
+
+variable "delegation_name" {
+  default = null
+}
+
+variable "delegation_ns" {
+  default = null
+}

--- a/custom_domains/infrastructure/workspace_variables/tscp.tfvars.json
+++ b/custom_domains/infrastructure/workspace_variables/tscp.tfvars.json
@@ -13,5 +13,12 @@
         "Service Line": "Teaching Workforce",
         "Service Offering": "Teacher services cloud",
         "Environment": "Prod"
-    }
+    },
+    "delegation_name":  "development",
+    "delegation_ns": [
+      "ns1-04.azure-dns.com.",
+      "ns2-04.azure-dns.net.",
+      "ns3-04.azure-dns.org.",
+      "ns4-04.azure-dns.info."
+    ]
 }


### PR DESCRIPTION
**Context**

Add the "development" NS record to the prod DNS zone for delegation to the dev DNS zone

**Changes proposed in this pull request**

- Add ns_record resource to terraform 
- Add variables

**Guidance to review**

make prod-domain domains-infra-plan
check the prod DNS zone for the NS record


